### PR TITLE
Added initial state for data out

### DIFF
--- a/ws2811.v
+++ b/ws2811.v
@@ -84,6 +84,10 @@ module ws2811
    assign data_request = reset_almost_done || led_almost_done;
    assign new_address  = (state == STATE_PRE) && (current_bit == 7);
    
+   initial begin
+      DO = 0;
+   end	
+	
    always @ (posedge clk) begin
       if (reset) begin
          address <= 0;


### PR DESCRIPTION
At least my simulations with iverilog and GTKWave require an initial value before the first clock pulse or later 'D0 = 1' assignments show up as indeterminate. I'm new to verilog so maybe I'm just doing something wrong.